### PR TITLE
Latest networkinfo code

### DIFF
--- a/Software/Python/bakebit_nanohat_oled.py
+++ b/Software/Python/bakebit_nanohat_oled.py
@@ -1141,7 +1141,7 @@ def show_vlan():
 
     vlan_info = []
 
-    vlan_cmd = "sudo grep -a VLAN " + lldpneigh_file
+    vlan_cmd = "sudo grep -a VLAN " + lldpneigh_file + " || grep -a VLAN " + cdpneigh_file
 
     if os.path.exists(lldpneigh_file):
 
@@ -1166,7 +1166,7 @@ def show_vlan():
     if display_state == 'menu':
         return
 
-    display_simple_table(vlan_info, back_button_req=1, title='--VLAN info--')
+    display_simple_table(vlan_info, back_button_req=1, title='--eth0 VLAN--')
 
 
 def show_wpa_passphrase():

--- a/Software/Python/scripts/networkinfo/cdpcleanup.sh
+++ b/Software/Python/scripts/networkinfo/cdpcleanup.sh
@@ -7,7 +7,7 @@ OUTPUTFILE="/tmp/cdpneigh.txt"
 
 #Clean up LLDP cache files
 logger "networkinfo script: cleaning CDP neighbour cache files"
-echo "No neighbour" > "$OUTPUTFILE"
+echo "No neighbour, takes up to 60 seconds" > "$OUTPUTFILE"
 #Tell me if eth0 is down 
 sudo /sbin/ethtool eth0 | grep -q "Link detected: no" && echo "eth0 is down" > "$OUTPUTFILE"
 

--- a/Software/Python/scripts/networkinfo/ipconfig.sh
+++ b/Software/Python/scripts/networkinfo/ipconfig.sh
@@ -43,5 +43,5 @@ if [ "$ETH0ISUP" ]; then
     echo "Duplex: $DUPLEX"
 
 else
-    echo "Disconnected"
+    echo "eth0 is down"
 fi

--- a/Software/Python/scripts/networkinfo/lldpcleanup.sh
+++ b/Software/Python/scripts/networkinfo/lldpcleanup.sh
@@ -7,7 +7,7 @@ OUTPUTFILE="/tmp/lldpneigh.txt"
 
 #Clean up LLDP cache files
 logger "networkinfo script: cleaning LLDP neighbour cache files"
-echo "No neighbour" > "$OUTPUTFILE"
+echo "No neighbour, takes up to 30 seconds" > "$OUTPUTFILE"
 #Tell me if eth0 is down 
 sudo /sbin/ethtool eth0 | grep -q "Link detected: no" && echo "eth0 is down" > "$OUTPUTFILE"
 

--- a/Software/Python/scripts/networkinfo/networkinfocron.sh
+++ b/Software/Python/scripts/networkinfo/networkinfocron.sh
@@ -9,10 +9,12 @@ do
   case "$line" in
   *"device (eth0): link connected"*)
     logger "networkinfo script: eth0 went up"
+    sudo /sbin/dhclient eth0 &
     sudo "$DIRECTORY"/lldpneigh.sh &
     sudo "$DIRECTORY"/cdpneigh.sh &
   ;;
   *"eth0: Link is Down"*)
+    sudo /sbin/dhclient -r eth0 &
     logger "networkinfo script: eth0 went down"
     sudo "$DIRECTORY"/lldpcleanup.sh &
     sudo "$DIRECTORY"/cdpcleanup.sh &


### PR DESCRIPTION
eth0 now releases IP address after going down and renews after goes up, native VLAN info is now taken from LLDP or CDP (supported LLDP-only previously)

I tested Classic mode, Wi-Fi console and Hotspot. Everything is working as expected as far as I can tell.